### PR TITLE
fix: ignore vscode folder except extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,11 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+
+# VSCode
+.vscode
+!.vscode/extensions.json
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged


### PR DESCRIPTION
# Description
Ignore all vscode related stuff, except the recommended extensions for the project